### PR TITLE
typst-ts-cli: Update to v0.7.0

### DIFF
--- a/bucket/typst-ts-cli.json
+++ b/bucket/typst-ts-cli.json
@@ -1,23 +1,16 @@
 {
-    "version": "0.6.0",
+    "version": "0.7.0",
     "homepage": "https://myriad-dreamin.github.io/typst.ts/cookery/guide/compiler/ts-cli.html",
     "description": "Run Typst in JavaScriptWorld, and precompile typst documents into Vector Format files.",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Myriad-Dreamin/typst.ts/releases/download/v0.6.0/typst-ts-x86_64-pc-windows-msvc.tar.gz",
-            "extract_dir": "typst-ts-x86_64-pc-windows-msvc/bin",
-            "hash": "d9f23d32af24fa922e9cf66eabbb7b1139149e0626978ddc8f8e9b9365ece4be"
-        },
-        "32bit": {
-            "url": "https://github.com/Myriad-Dreamin/typst.ts/releases/download/v0.6.0/typst-ts-i686-pc-windows-msvc.tar.gz",
-            "extract_dir": "typst-ts-i686-pc-windows-msvc/bin",
-            "hash": "93584d9d82b1a467cec2508e4ea7e17e77fb5c6c3249b66b84857f0e700074cc"
+            "url": "https://github.com/Myriad-Dreamin/typst.ts/releases/download/v0.7.0/typst-ts-x86_64-pc-windows-msvc.zip",
+            "hash": "d661e47fb5c0e2753b70207706670379095ee71232ab02924a966d901ec5656c"
         },
         "arm64": {
-            "url": "https://github.com/Myriad-Dreamin/typst.ts/releases/download/v0.6.0/typst-ts-aarch64-pc-windows-msvc.tar.gz",
-            "extract_dir": "typst-ts-aarch64-pc-windows-msvc/bin",
-            "hash": "eac6fba64f3c92cc075bfe6a758cd48ab87bfb2c42b1a3648b129b3e7b5ffa1f"
+            "url": "https://github.com/Myriad-Dreamin/typst.ts/releases/download/v0.7.0/typst-ts-aarch64-pc-windows-msvc.zip",
+            "hash": "22faf110a71fa303984e98f9ba8199021731e742b81143b67a844095a7f0c67a"
         }
     },
     "bin": "typst-ts-cli.exe",
@@ -27,16 +20,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Myriad-Dreamin/typst.ts/releases/download/v$version/typst-ts-x86_64-pc-windows-msvc.tar.gz",
-                "extract_dir": "typst-ts-x86_64-pc-windows-msvc/bin"
-            },
-            "32bit": {
-                "url": "https://github.com/Myriad-Dreamin/typst.ts/releases/download/v$version/typst-ts-i686-pc-windows-msvc.tar.gz",
-                "extract_dir": "typst-ts-i686-pc-windows-msvc/bin"
+                "url": "https://github.com/Myriad-Dreamin/typst.ts/releases/download/v$version/typst-ts-x86_64-pc-windows-msvc.zip"
             },
             "arm64": {
-                "url": "https://github.com/Myriad-Dreamin/typst.ts/releases/download/v$version/typst-ts-aarch64-pc-windows-msvc.tar.gz",
-                "extract_dir": "typst-ts-aarch64-pc-windows-msvc/bin"
+                "url": "https://github.com/Myriad-Dreamin/typst.ts/releases/download/v$version/typst-ts-aarch64-pc-windows-msvc.zip"
             }
         }
     }


### PR DESCRIPTION
32-bit binaries are no longer available, and `*.tar.gz` are replaced by `*.zip`.

https://github.com/Myriad-Dreamin/typst.ts/pull/755

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
